### PR TITLE
Warp Rotation Bugfix

### DIFF
--- a/Assets/Scripts/Editing/EditGM_utilities.cs
+++ b/Assets/Scripts/Editing/EditGM_utilities.cs
@@ -156,9 +156,11 @@ public partial class EditGM {
         levelData.warpSet.Add(inWarp);
 
         // corresponding checkpoint object is added to chkpntMap
-        Vector3 v3 = inWarp.orient.locus.ToUnitySpace();
-        v3.z = GetLayerDepth(inWarp.orient.layer);
-        GameObject go = Instantiate(warpTool, v3, Quaternion.identity) as GameObject;
+        HexOrient o = inWarp.orient;
+        Vector3 v3 = o.locus.ToUnitySpace();
+        v3.z = GetLayerDepth(o.layer);
+        Quaternion r = Quaternion.Euler(0, 0, 30 * o.rotation);
+        GameObject go = Instantiate(warpTool, v3, r) as GameObject;
         go.GetComponent<SpecialCreator>().enabled = false;
         go.transform.SetParent(warpMap.transform); // <2>
 


### PR DESCRIPTION
When in editor, there is a bug that places warps at the identity rotation regardless of the current rotation of the warp tool. This bug fixes that and tidies up the relevant section of code slightly.